### PR TITLE
Fix satellites reading issues

### DIFF
--- a/app/src/main/java/com/zhufucdev/motion_emulator/hook/LocationHooker.kt
+++ b/app/src/main/java/com/zhufucdev/motion_emulator/hook/LocationHooker.kt
@@ -335,15 +335,17 @@ object LocationHooker : YukiBaseHooker() {
                 injectMember {
                     method {
                         name = "registerGnssStatusCallback"
-                        param(classOf<Executor>(), classOf<GnssStatus.Callback>())
                         returnType = BooleanType
-                    }
+                    }.all()
                     replaceAny {
                         if (Scheduler.satellites <= 0) {
                             return@replaceAny callOriginal()
                         }
-
-                        val callback = args(1).cast<GnssStatus.Callback>()
+                        val callback = if (args[0] is GnssStatus.Callback) {
+                            args(0).cast<GnssStatus.Callback>()
+                        } else {
+                            args(1).cast<GnssStatus.Callback>()
+                        }
                         callback?.onStarted()
                         callback?.onFirstFix(1000 + Random.nextInt(-500, 500))
                         timer(name = "satellite heartbeat", period = 1000) {

--- a/app/src/main/java/com/zhufucdev/motion_emulator/hook/Scheduler.kt
+++ b/app/src/main/java/com/zhufucdev/motion_emulator/hook/Scheduler.kt
@@ -157,7 +157,7 @@ object Scheduler {
 
         length = emulation.trace.circumference(MapProjector)
         duration = length / emulation.velocity // in seconds
-        this.satellites = satellites
+        this.satellites = emulation.satelliteCount
 
         hooking = true
         updateState(true)


### PR DESCRIPTION
这个问题导致不能正常hook registerGnssStatusCallback：
```
injectMember {
                    method {
                        name = "registerGnssStatusCallback"
                        param(classOf<Executor>(), classOf<GnssStatus.Callback>())
                        returnType = BooleanType
                    }
                    replaceAny {
                        if (Scheduler.satellites <= 0) {
                            return@replaceAny callOriginal()
                        }

                        val callback = args(1).cast<GnssStatus.Callback>()
                        callback?.onStarted()
                        callback?.onFirstFix(1000 + Random.nextInt(-500, 500))
                        timer(name = "satellite heartbeat", period = 1000) {
                            callback?.onSatelliteStatusChanged(fakeGnssStatus ?: return@timer)
                        }
                        true
                    }
                }
```

此处会执行原方法：
```
if (Scheduler.satellites <= 0) {
                            return@replaceAny callOriginal()
                        }
```