### PR TITLE
Fix critical errors with Hook AMap

### DIFF
--- a/app/src/main/java/com/zhufucdev/motion_emulator/hook/LocationHooker.kt
+++ b/app/src/main/java/com/zhufucdev/motion_emulator/hook/LocationHooker.kt
@@ -546,7 +546,7 @@ object LocationHooker : YukiBaseHooker() {
                     emptyParam()
                 }
                 beforeHook {
-                    val classLoader = (args[0] as Context).classLoader
+                    val classLoader = instanceClass.classLoader
                     classOf<AMapLocation>(classLoader).hook {
                         common()
                     }


### PR DESCRIPTION
修复Hook onCreate 获取 classloader 时的错误